### PR TITLE
Add script_tag rule

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+AllowShortFunctionsOnASingleLine: SFS_None
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterEnum: false
+  AfterStruct: false
+  SplitEmptyFunction: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+build
 node_modules
 yarn.lock

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,9 +7,9 @@
         "src"
       ],
       "sources": [
-        "bindings/node/binding.cc",
         "src/parser.c",
-        # If your language uses an external scanner, add it here.
+        "src/scanner.cc",
+        "bindings/node/binding.cc",
       ],
       "cflags_c": [
         "-std=c99",

--- a/corpus/main.txt
+++ b/corpus/main.txt
@@ -1,0 +1,8 @@
+===================================
+Script
+===================================
+script(src='/javascripts/app.js')
+---
+
+(fragment
+  (script_tag))

--- a/example-file
+++ b/example-file
@@ -1,0 +1,1 @@
+script(src='/javascripts/app.js')

--- a/grammar.js
+++ b/grammar.js
@@ -1,6 +1,13 @@
 module.exports = grammar({
   name: "pug",
+
+  externals: ($) => [$._tag_name, $._script_tag_name, $._implicit_end_tag],
+
   rules: {
-    source_file: ($) => "hello",
+    fragment: ($) => repeat($._node),
+
+    _node: ($) => choice($.script_tag),
+
+    script_tag: ($) => seq($._script_tag_name),
   },
 });

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,9 +1,30 @@
 {
   "name": "pug",
   "rules": {
-    "source_file": {
-      "type": "STRING",
-      "value": "hello"
+    "fragment": {
+      "type": "REPEAT",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_node"
+      }
+    },
+    "_node": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "script_tag"
+        }
+      ]
+    },
+    "script_tag": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_script_tag_name"
+        }
+      ]
     }
   },
   "extras": [
@@ -14,7 +35,20 @@
   ],
   "conflicts": [],
   "precedences": [],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_tag_name"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_script_tag_name"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_implicit_end_tag"
+    }
+  ],
   "inline": [],
   "supertypes": []
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,11 +1,22 @@
 [
   {
-    "type": "source_file",
+    "type": "fragment",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "script_tag",
+          "named": true
+        }
+      ]
+    }
   },
   {
-    "type": "hello",
-    "named": false
+    "type": "script_tag",
+    "named": true,
+    "fields": {}
   }
 ]

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,31 +6,46 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 4
-#define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 3
+#define STATE_COUNT 6
+#define LARGE_STATE_COUNT 4
+#define SYMBOL_COUNT 8
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 2
-#define EXTERNAL_TOKEN_COUNT 0
+#define TOKEN_COUNT 4
+#define EXTERNAL_TOKEN_COUNT 3
 #define FIELD_COUNT 0
-#define MAX_ALIAS_SEQUENCE_LENGTH 1
+#define MAX_ALIAS_SEQUENCE_LENGTH 2
 #define PRODUCTION_ID_COUNT 1
 
 enum {
-  anon_sym_hello = 1,
-  sym_source_file = 2,
+  sym__tag_name = 1,
+  sym__script_tag_name = 2,
+  sym__implicit_end_tag = 3,
+  sym_fragment = 4,
+  sym__node = 5,
+  sym_script_tag = 6,
+  aux_sym_fragment_repeat1 = 7,
 };
 
 static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
-  [anon_sym_hello] = "hello",
-  [sym_source_file] = "source_file",
+  [sym__tag_name] = "_tag_name",
+  [sym__script_tag_name] = "_script_tag_name",
+  [sym__implicit_end_tag] = "_implicit_end_tag",
+  [sym_fragment] = "fragment",
+  [sym__node] = "_node",
+  [sym_script_tag] = "script_tag",
+  [aux_sym_fragment_repeat1] = "fragment_repeat1",
 };
 
 static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
-  [anon_sym_hello] = anon_sym_hello,
-  [sym_source_file] = sym_source_file,
+  [sym__tag_name] = sym__tag_name,
+  [sym__script_tag_name] = sym__script_tag_name,
+  [sym__implicit_end_tag] = sym__implicit_end_tag,
+  [sym_fragment] = sym_fragment,
+  [sym__node] = sym__node,
+  [sym_script_tag] = sym_script_tag,
+  [aux_sym_fragment_repeat1] = aux_sym_fragment_repeat1,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -38,13 +53,33 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = true,
   },
-  [anon_sym_hello] = {
-    .visible = true,
-    .named = false,
+  [sym__tag_name] = {
+    .visible = false,
+    .named = true,
   },
-  [sym_source_file] = {
+  [sym__script_tag_name] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym__implicit_end_tag] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_fragment] = {
     .visible = true,
     .named = true,
+  },
+  [sym__node] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_script_tag] = {
+    .visible = true,
+    .named = true,
+  },
+  [aux_sym_fragment_repeat1] = {
+    .visible = false,
+    .named = false,
   },
 };
 
@@ -61,6 +96,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [1] = 1,
   [2] = 2,
   [3] = 3,
+  [4] = 4,
+  [5] = 5,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -68,30 +105,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(5);
-      if (lookahead == 'h') ADVANCE(1);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(0)
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (eof) ADVANCE(1);
       END_STATE();
     case 1:
-      if (lookahead == 'e') ADVANCE(3);
-      END_STATE();
-    case 2:
-      if (lookahead == 'l') ADVANCE(4);
-      END_STATE();
-    case 3:
-      if (lookahead == 'l') ADVANCE(2);
-      END_STATE();
-    case 4:
-      if (lookahead == 'o') ADVANCE(6);
-      END_STATE();
-    case 5:
       ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 6:
-      ACCEPT_TOKEN(anon_sym_hello);
       END_STATE();
     default:
       return false;
@@ -99,48 +117,104 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 }
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
-  [0] = {.lex_state = 0},
-  [1] = {.lex_state = 0},
-  [2] = {.lex_state = 0},
-  [3] = {.lex_state = 0},
+  [0] = {.lex_state = 0, .external_lex_state = 1},
+  [1] = {.lex_state = 0, .external_lex_state = 2},
+  [2] = {.lex_state = 0, .external_lex_state = 2},
+  [3] = {.lex_state = 0, .external_lex_state = 2},
+  [4] = {.lex_state = 0, .external_lex_state = 2},
+  [5] = {.lex_state = 0},
+};
+
+enum {
+  ts_external_token__tag_name = 0,
+  ts_external_token__script_tag_name = 1,
+  ts_external_token__implicit_end_tag = 2,
+};
+
+static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
+  [ts_external_token__tag_name] = sym__tag_name,
+  [ts_external_token__script_tag_name] = sym__script_tag_name,
+  [ts_external_token__implicit_end_tag] = sym__implicit_end_tag,
+};
+
+static const bool ts_external_scanner_states[3][EXTERNAL_TOKEN_COUNT] = {
+  [1] = {
+    [ts_external_token__tag_name] = true,
+    [ts_external_token__script_tag_name] = true,
+    [ts_external_token__implicit_end_tag] = true,
+  },
+  [2] = {
+    [ts_external_token__script_tag_name] = true,
+  },
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
-    [anon_sym_hello] = ACTIONS(1),
+    [sym__tag_name] = ACTIONS(1),
+    [sym__script_tag_name] = ACTIONS(1),
+    [sym__implicit_end_tag] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(3),
-    [anon_sym_hello] = ACTIONS(3),
+    [sym_fragment] = STATE(5),
+    [sym__node] = STATE(2),
+    [sym_script_tag] = STATE(2),
+    [aux_sym_fragment_repeat1] = STATE(2),
+    [ts_builtin_sym_end] = ACTIONS(3),
+    [sym__script_tag_name] = ACTIONS(5),
+  },
+  [2] = {
+    [sym__node] = STATE(3),
+    [sym_script_tag] = STATE(3),
+    [aux_sym_fragment_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(7),
+    [sym__script_tag_name] = ACTIONS(5),
+  },
+  [3] = {
+    [sym__node] = STATE(3),
+    [sym_script_tag] = STATE(3),
+    [aux_sym_fragment_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(9),
+    [sym__script_tag_name] = ACTIONS(11),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
   [0] = 1,
-    ACTIONS(5), 1,
+    ACTIONS(14), 2,
+      sym__script_tag_name,
       ts_builtin_sym_end,
-  [4] = 1,
-    ACTIONS(7), 1,
+  [5] = 1,
+    ACTIONS(16), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 4,
+  [SMALL_STATE(4)] = 0,
+  [SMALL_STATE(5)] = 5,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
-  [7] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 0),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [7] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 1),
+  [9] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2),
+  [11] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(4),
+  [14] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_tag, 1),
+  [16] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+void *tree_sitter_pug_external_scanner_create(void);
+void tree_sitter_pug_external_scanner_destroy(void *);
+bool tree_sitter_pug_external_scanner_scan(void *, TSLexer *, const bool *);
+unsigned tree_sitter_pug_external_scanner_serialize(void *, char *);
+void tree_sitter_pug_external_scanner_deserialize(void *, const char *, unsigned);
+
 #ifdef _WIN32
 #define extern __declspec(dllexport)
 #endif
@@ -168,6 +242,15 @@ extern const TSLanguage *tree_sitter_pug(void) {
     .alias_sequences = &ts_alias_sequences[0][0],
     .lex_modes = ts_lex_modes,
     .lex_fn = ts_lex,
+    .external_scanner = {
+      &ts_external_scanner_states[0][0],
+      ts_external_scanner_symbol_map,
+      tree_sitter_pug_external_scanner_create,
+      tree_sitter_pug_external_scanner_destroy,
+      tree_sitter_pug_external_scanner_scan,
+      tree_sitter_pug_external_scanner_serialize,
+      tree_sitter_pug_external_scanner_deserialize,
+    },
     .primary_state_ids = ts_primary_state_ids,
   };
   return &language;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -149,17 +149,17 @@ void *tree_sitter_pug_external_scanner_create() {
   return new Scanner();
 }
 
-bool tree_sitter_html_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+bool tree_sitter_pug_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
   Scanner *scanner = static_cast<Scanner *>(payload);
   return scanner->scan(lexer, valid_symbols);
 }
 
-unsigned tree_sitter_html_external_scanner_serialize(void *payload, char *buffer) {
+unsigned tree_sitter_pug_external_scanner_serialize(void *payload, char *buffer) {
   Scanner *scanner = static_cast<Scanner *>(payload);
   return scanner->serialize(buffer);
 }
 
-void tree_sitter_html_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+void tree_sitter_pug_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
   Scanner *scanner = static_cast<Scanner *>(payload);
   scanner->deserialize(buffer, length);
 }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,0 +1,172 @@
+#include <tree_sitter/parser.h>
+#include <string>
+#include <vector>
+#include <cwctype>
+#include "tag.h"
+
+namespace {
+
+using std::vector;
+using std::string;
+
+enum TokenType {
+  TAG_NAME,
+  SCRIPT_TAG_NAME,
+  IMPLICIT_END_TAG,
+};
+
+struct Scanner {
+  Scanner() {}
+
+  unsigned serialize(char *buffer) {
+    uint16_t tag_count = tags.size() > UINT16_MAX ? UINT16_MAX : tags.size();
+    uint16_t serialized_tag_count = 0;
+
+    unsigned i = sizeof(tag_count);
+    std::memcpy(&buffer[i], &tag_count, sizeof(tag_count));
+    i += sizeof(tag_count);
+
+    for (; serialized_tag_count < tag_count; serialized_tag_count++) {
+      Tag &tag = tags[serialized_tag_count];
+      if (tag.type == CUSTOM) {
+        unsigned name_length = tag.custom_tag_name.size();
+        if (name_length > UINT8_MAX) name_length = UINT8_MAX;
+        if (i + 2 + name_length >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) break;
+        buffer[i++] = static_cast<char>(tag.type);
+        buffer[i++] = name_length;
+        tag.custom_tag_name.copy(&buffer[i], name_length);
+        i += name_length;
+      } else {
+        if (i + 1 >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) break;
+        buffer[i++] = static_cast<char>(tag.type);
+      }
+    }
+
+    std::memcpy(&buffer[0], &serialized_tag_count, sizeof(serialized_tag_count));
+    return i;
+  }
+
+  void deserialize(const char *buffer, unsigned length) {
+    tags.clear();
+    if (length > 0) {
+      unsigned i = 0;
+      uint16_t tag_count, serialized_tag_count;
+
+      std::memcpy(&serialized_tag_count, &buffer[i], sizeof(serialized_tag_count));
+      i += sizeof(serialized_tag_count);
+
+      std::memcpy(&tag_count, &buffer[i], sizeof(tag_count));
+      i += sizeof(tag_count);
+
+      tags.resize(tag_count);
+      for (unsigned j = 0; j < serialized_tag_count; j++) {
+        Tag &tag = tags[j];
+        tag.type = static_cast<TagType>(buffer[i++]);
+        if (tag.type == CUSTOM) {
+          uint16_t name_length = static_cast<uint8_t>(buffer[i++]);
+          tag.custom_tag_name.assign(&buffer[i], &buffer[i + name_length]);
+          i += name_length;
+        }
+      }
+    }
+  }
+
+  string scan_tag(TSLexer *lexer) {
+    string tag_name;
+    while (iswalnum(lexer->lookahead) || lexer->lookahead == '-' || lexer->lookahead == ':') {
+      tag_name += towupper(lexer->lookahead);
+      lexer->advance(lexer, false);
+    }
+    return tag_name;
+  }
+
+  bool scan_implicit_end_tag(TSLexer *lexer) {
+    Tag *parent = tags.empty() ? NULL : &tags.back();
+
+      if (parent && parent->is_void()) {
+        tags.pop_back();
+        lexer->result_symbol = IMPLICIT_END_TAG;
+        return true;
+      }
+
+    string tag_name = scan_tag(lexer);
+    if (tag_name.empty()) return false;
+
+    Tag next_tag = Tag::for_name(tag_name);
+
+    if (parent) {
+      tags.pop_back();
+      lexer->result_symbol = IMPLICIT_END_TAG;
+      return true;
+    }
+
+    return false;
+  }
+
+  bool scan_tag_name(TSLexer *lexer) {
+    string tag_name = scan_tag(lexer);
+    if (tag_name.empty()) return false;
+    Tag tag = Tag::for_name(tag_name);
+    tags.push_back(tag);
+    switch (tag.type) {
+      case SCRIPT:
+        lexer->result_symbol = SCRIPT_TAG_NAME;
+        break;
+      default:
+        lexer->result_symbol = TAG_NAME;
+        break;
+    }
+    return true;
+  }
+
+  bool scan(TSLexer *lexer, const bool *valid_symbols) {
+    while (iswspace(lexer->lookahead)) {
+      lexer->advance(lexer, true);
+    }
+
+    switch (lexer->lookahead) {
+      case '\0':
+        if (valid_symbols[IMPLICIT_END_TAG]) {
+          return scan_implicit_end_tag(lexer);
+        }
+        break;
+
+      default:
+        return scan_tag_name(lexer);
+    }
+
+    return false;
+  }
+
+  vector<Tag> tags;
+};
+
+} // namespace
+
+extern "C" {
+
+void *tree_sitter_pug_external_scanner_create() {
+  return new Scanner();
+}
+
+bool tree_sitter_html_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+  Scanner *scanner = static_cast<Scanner *>(payload);
+  return scanner->scan(lexer, valid_symbols);
+}
+
+unsigned tree_sitter_html_external_scanner_serialize(void *payload, char *buffer) {
+  Scanner *scanner = static_cast<Scanner *>(payload);
+  return scanner->serialize(buffer);
+}
+
+void tree_sitter_html_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+  Scanner *scanner = static_cast<Scanner *>(payload);
+  scanner->deserialize(buffer, length);
+}
+
+void tree_sitter_pug_external_scanner_destroy(void *payload) {
+  Scanner *scanner = static_cast<Scanner *>(payload);
+  delete scanner;
+}
+
+}

--- a/src/tag.h
+++ b/src/tag.h
@@ -1,0 +1,50 @@
+#include <string>
+#include <map>
+
+using std::string;
+using std::map;
+
+enum TagType {
+  END_OF_VOID_TAGS,
+
+  SCRIPT,
+
+  CUSTOM
+};
+
+static const map<string, TagType> get_tag_map() {
+  map<string, TagType> result;
+#define TAG(name) result[#name] = name
+  TAG(SCRIPT);
+#undef TAG
+  return result;
+}
+
+static const map<string, TagType> TAG_TYPES_BY_TAG_NAME = get_tag_map();
+
+struct Tag {
+  TagType type;
+  string custom_tag_name;
+
+  // This default constructor is used in the case where there is not enough space
+  // in the serialization buffer to store all of the tags. In that case, tags
+  // that cannot be serialized will be treated as having an unknown type. These
+  // tags will be closed via implicit end tags regardless of the next closing
+  // tag is encountered.
+  Tag() : type(END_OF_VOID_TAGS) {}
+
+  Tag(TagType type, const string &name) : type(type), custom_tag_name(name) {}
+
+  inline bool is_void() const {
+    return type < END_OF_VOID_TAGS;
+  }
+
+  static inline Tag for_name(const string &name) {
+    map<string, TagType>::const_iterator type = TAG_TYPES_BY_TAG_NAME.find(name);
+    if (type != TAG_TYPES_BY_TAG_NAME.end()) {
+      return Tag(type->second, string());
+    } else {
+      return Tag(CUSTOM, name);
+    }
+  }
+};


### PR DESCRIPTION
Generates the following syntax tree from source code `script(src='/javascripts/app.js')`:
<img width="269" alt="CleanShot 2023-05-04 at 15 54 48@2x" src="https://user-images.githubusercontent.com/2354251/236347224-b04f21fc-bbea-46ac-af91-b6397ebf3081.png">
